### PR TITLE
Identify duplicates within organisation

### DIFF
--- a/endpoint_checker/endpoint_checker.ipynb
+++ b/endpoint_checker/endpoint_checker.ipynb
@@ -215,6 +215,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "60391993-7245-4eab-a3af-dcaf4768efd8",
+   "metadata": {},
+   "source": [
+    "#### Duplicate entities within organisation\n",
+    "\n",
+    "The below table displays duplicates in the data provided identified using the geographical info (geometry and point column)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca90666c-22b5-4b6c-a5f3-2cf0a4427c71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not (results[['geometry', 'point']].apply(lambda x: x.str.strip() == '')).all().all():\n",
+    "    grouped = results.groupby(['geometry', 'point'])\n",
+    "    grouped_list=[]\n",
+    "    for key, value in (grouped.groups).items():\n",
+    "        if len(value) > 1 and key[1] !='':\n",
+    "            filtered_df = results[(results['geometry'] == key[0]) & (results['point'] == key[1])]\n",
+    "            grouped_list.append(filtered_df)\n",
+    "\n",
+    "    if len(grouped_list)>1:\n",
+    "        for i in range(len(grouped_list)):\n",
+    "            display(grouped_list[i])\n",
+    "    else:\n",
+    "        print(\"No duplicates found in the given dataset\")\n",
+    "else:\n",
+    "    print(\"No geometry or point data in the dataset\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2555d950",


### PR DESCRIPTION
Card: https://trello.com/c/EcaPjxmx/511-identify-duplicate-entities-within-same-organisation-and-take-necessary-steps-to-eliminate-them

This PR adds a section in the validator to check for duplicate entities within organisation and displays them.
Displays appropriate message based on the use case:

1.For datasets without geographical data it displays "No geometry or point data in the dataset"
2.For datasets without any duplicates it displays "No duplicates found in the given dataset"