### PR TITLE
Adjust get_workflow_data to fetch data from config repo

### DIFF
--- a/endpoint_checker/functions.py
+++ b/endpoint_checker/functions.py
@@ -139,7 +139,8 @@ def get_workflow_data(data_dir,collection,dataset):
                 os.path.join(pipeline_dir, pipeline_csv),
             )
             except HTTPError as err:
-                print(err)
+                print(f"Decentralised Collection Error: +{e}")
+                print(f"Centralised (Config) Repository Error: +{err}")
 
     # add transformedd, dataset and issue directories
     dataset_dir = os.path.join(data_dir,"dataset")

--- a/endpoint_checker/functions.py
+++ b/endpoint_checker/functions.py
@@ -132,9 +132,15 @@ def get_workflow_data(data_dir,collection,dataset):
                 os.path.join(pipeline_dir, pipeline_csv),
             )
         except HTTPError as e:
-            print(e)
-    
-    
+            collection_affix = collection.replace("-collection", "")
+            try:
+                urllib.request.urlretrieve(
+                f"{source_url}/config/main/pipeline/{collection_affix}/{pipeline_csv}",
+                os.path.join(pipeline_dir, pipeline_csv),
+            )
+            except HTTPError as err:
+                print(err)
+
     # add transformedd, dataset and issue directories
     dataset_dir = os.path.join(data_dir,"dataset")
     os.makedirs(dataset_dir,exist_ok=True)


### PR DESCRIPTION
Adjust the endpoint_checker so that it automatically grabs the workflow data from the config repository, if the request to the original collection fails.