### PR TITLE
Report to compare endpoint's entity count with platform

### DIFF
--- a/service_report/Compare_entity_count.ipynb
+++ b/service_report/Compare_entity_count.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "75aa7cf7-84e8-4b2d-9b2f-40ef543d8d0a",
+   "metadata": {},
+   "source": [
+    "# Compare Entity Count\n",
+    "**Author**:  Kena Vyas <br>\n",
+    "**Date**:  2nd May 2024 <br>\n",
+    "**Data Scope**: First four datasets <br>\n",
+    "**Report Type**: Recurring daily <br>\n",
+    "\n",
+    "## Purpose\n",
+    "This report provides a comparative analysis of the entity counts for each endpoint against the corresponding counts on the platform per Organisation per dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "752d7b3a-3ee7-45b2-9ac6-e9470abada00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib\n",
+    "import pandas as pd\n",
+    "import ipywidgets as widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f8c51819-c013-4473-a08d-140fe69d6bd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5926cf1e860a4e4da1b1d6977c76bc93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Select Dataset:', options={'Article 4 direction': 'article-4-direc…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "datasette_url = \"https://datasette.planning.data.gov.uk/\"\n",
+    "result_df = pd.DataFrame()\n",
+    "\n",
+    "def get_endpoint_resource_info(dataset):\n",
+    "    params = urllib.parse.urlencode({\n",
+    "        \"sql\": f\"\"\"\n",
+    "        select p.organisation,p.start_date,re.name,re.collection,re.pipeline,re.endpoint,\n",
+    "        re.endpoint_url,re.status,re.resource,re.latest_log_entry_date,re.endpoint_entry_date\n",
+    "        from provision p join reporting_latest_endpoints re \n",
+    "        on p.organisation= replace(re.organisation, '-eng', '') \n",
+    "        where cohort in ('ODP-Track1','ODP-Track2','ODP-Track3','ODP-Track4','RIPA-Beta','RIPA-BOPS') and \n",
+    "        re.pipeline = '{dataset}' and status='200' \n",
+    "        group by endpoint\n",
+    "        \"\"\",\n",
+    "        \"_size\": \"max\"\n",
+    "    })\n",
+    "    \n",
+    "    url = f\"{datasette_url}digital-land.csv?{params}\"\n",
+    "    df = pd.read_csv(url)\n",
+    "    return df\n",
+    " \n",
+    "dataset_options = {\n",
+    "    \"Article 4 direction\": \"article-4-direction\",\"Article 4 direction area\": \"article-4-direction-area\",\"Conservation area\": \"conservation-area\",\n",
+    "    \"Listed building outline\": \"listed-building-outline\",\"Tree\": \"tree\",\"Tree preservation order\": \"tree-preservation-order\",\"Tree preservation zone\": \"tree-preservation-zone\",    \n",
+    "}\n",
+    "\n",
+    "dataset_dropdown = widgets.Dropdown(\n",
+    "    options=dataset_options,\n",
+    "    description=\"Select Dataset:\",\n",
+    ")\n",
+    "\n",
+    "widgets.interact(get_endpoint_resource_info, dataset=dataset_dropdown)\n",
+    "initial_dataset = dataset_dropdown.value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "17b26fdd-2643-45a5-929a-b8ecac1b534a",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6c49eeff33704b78be1c69c4424cc2e1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Select Dataset:', options={'Article 4 direction': 'article-4-direc…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def get_endpoint_resource_info_(dataset):\n",
+    "    result_df = get_endpoint_resource_info(dataset)\n",
+    "    resource_list=result_df['resource']\n",
+    "    dataset_input=result_df['pipeline'][0]\n",
+    "    info={}\n",
+    "    \n",
+    "    for res in resource_list:\n",
+    "        info[res] = []\n",
+    "        params = urllib.parse.urlencode({\n",
+    "                \"sql\": f\"\"\"\n",
+    "                select count(*) from ( \n",
+    "                    select rowid, end_date, fact, entry_date, entry_number, resource, start_date \n",
+    "                    from fact_resource \n",
+    "                    where \"resource\" ='{res}' group by entry_number\n",
+    "                );\n",
+    "                \"\"\",\n",
+    "                \"_size\": \"max\"\n",
+    "            })\n",
+    "        \n",
+    "        url = f\"{datasette_url}{dataset_input}.csv?{params}\"\n",
+    "        df = pd.read_csv(url)\n",
+    "        info[res].append(df.iloc[0, 0])\n",
+    "\n",
+    "    updated_dict={}\n",
+    "    for index, row in result_df.iterrows():\n",
+    "        resource, organisation = row['resource'], row['organisation']\n",
+    "        if resource in info:\n",
+    "            updated_dict[organisation] = info[resource]\n",
+    "\n",
+    "    org_entity={}\n",
+    "    org_list=result_df['organisation']\n",
+    "    \n",
+    "    for org in org_list:\n",
+    "        org_entity[org] = []\n",
+    "        params = urllib.parse.urlencode({\n",
+    "                    \"sql\": f\"\"\"\n",
+    "                    select entity from organisation where organisation = '{org}'\n",
+    "                    \"\"\",\n",
+    "                    \"_size\": \"max\"\n",
+    "                })\n",
+    "            \n",
+    "        url = f\"{datasette_url}digital-land.csv?{params}\"\n",
+    "        df = pd.read_csv(url)\n",
+    "        org_entity[org]=df.iloc[0, 0]\n",
+    "\n",
+    "    entity_count={}\n",
+    "    for key,value in org_entity.items():\n",
+    "        entity_count[key]=[]\n",
+    "        params = urllib.parse.urlencode({\n",
+    "                \"sql\": f\"\"\"\n",
+    "                select count(*) from (select * from entity where \"organisation_entity\" = '{value}')\n",
+    "                \"\"\",\n",
+    "                \"_size\": \"max\"\n",
+    "            })\n",
+    "        \n",
+    "        url = f\"{datasette_url}{dataset_input}.csv?{params}\"\n",
+    "        df = pd.read_csv(url)\n",
+    "        if key in updated_dict:\n",
+    "            updated_dict[key].append(df.iloc[0, 0])\n",
+    "\n",
+    "    filtered_data = {key: value for key, value in updated_dict.items() if value[0] != value[1]}\n",
+    "\n",
+    "    df = pd.DataFrame(filtered_data).transpose()\n",
+    "    if df.empty:\n",
+    "        return \"Entities Match for all endpoints\"\n",
+    "    df.columns = ['Latest resource entity count', 'Platform entity count']\n",
+    "    print(\"Dataset : \",dataset_input)\n",
+    "    return df\n",
+    "\n",
+    "widgets.interact(get_endpoint_resource_info_, dataset=dataset_dropdown)\n",
+    "initial_dataset = dataset_dropdown.value"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This report provides a comparative analysis of the entity counts for each endpoint against the corresponding counts on the platform per Organisation per dataset.

The report considers ODP Organisations.

Approach:
For each endpoint the report gets the entity count it has on its latest resource. (Identified using fact_resource)
It then creates a table that compares it with what is present on the platform. (Identified using the entity table filtered with Organisation_entity)

Note:
This report doesn't consider the case when there are multiple endpoints used per Org per Dataset yet.