### PR TITLE
add new point duplicate check

### DIFF
--- a/tools/endpoint_checker/endpoint_checker.ipynb
+++ b/tools/endpoint_checker/endpoint_checker.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "af9959de-69a3-4199-86ad-ecf5fa3150c2",
    "metadata": {
     "tags": []
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "06f3f438-0b45-485e-b1f2-6e9b4bb01729",
    "metadata": {
     "tags": []
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9e38144f-1c71-4283-840e-bddffd3ea776",
    "metadata": {
     "tags": []
@@ -358,12 +358,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# download live dataset\n",
     "download_datasette_dataset(dataset,f\"{data_dir}/entity_resolution\")\n",
-    "live_dataset_path = os.path.join(f\"{data_dir}/entity_resolution\",f'{dataset}.sqlite3')\n",
-    "duplicates = get_duplicates_between_orgs(live_dataset_path,f'../data/endpoint_checker/dataset/{dataset}.sqlite3')\n",
     "\n",
-    "if duplicates.empty:\n",
-    "    print(\"No duplicate entities found with existing entities\")\n",
+    "live_dataset_path = os.path.join(data_dir, \"entity_resolution\", f\"{dataset}.sqlite3\")\n",
+    "new_dataset_path = os.path.join(data_dir, \"dataset\", f\"{dataset}.sqlite3\")\n",
+    "\n",
+    "duplicates = get_duplicates_between_orgs(dataset, live_dataset_path, new_dataset_path)\n",
     "\n",
     "duplicates"
    ]
@@ -378,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "870521b7-4394-485a-a77f-cf413f2da4cb",
    "metadata": {},
    "outputs": [],
@@ -442,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "8e383e7d",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add new functionality to the `get_duplicates_between_orgs()` function in endpoint checker so that when run against a tree dataset with point data it will use points to check for geographical duplicates instead of polygons

## Related Tickets & Documents
https://mhclgdigital.atlassian.net/browse/DATA-875
