### PR TITLE
Gs/duplicate logic update

### DIFF
--- a/reports/find_conservation_area_duplicates/map_conservation_area_duplicates.ipynb
+++ b/reports/find_conservation_area_duplicates/map_conservation_area_duplicates.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,6 +55,9 @@
     "import os\n",
     "import folium\n",
     "import ipywidgets as widgets\n",
+    "from datetime import datetime\n",
+    "\n",
+    "td = datetime.today().strftime('%Y-%m-%d')\n",
     "\n",
     "output_dir = \"../../data/reports/conservation-area-duplicates/\"\n",
     "os.makedirs(output_dir, exist_ok=True)"
@@ -62,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,17 +187,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "452\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get orgs and flag ODP\n",
     "provisions_df = get_provisions()\n",
@@ -206,23 +201,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8407\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# CA from pdp\n",
-    "ca_df = pd.read_csv(\"https://files.planning.data.gov.uk/dataset/conservation-area.csv\",\n",
+    "ca_in = pd.read_csv(\"https://files.planning.data.gov.uk/dataset/conservation-area.csv\",\n",
     "                            usecols = [\"entity\", \"name\", \"organisation-entity\", \"reference\", \"entry-date\", \"point\", \"geometry\"])\n",
     "\n",
-    "ca_df.columns = [x.replace(\"-\", \"_\") for x in ca_df.columns]\n",
+    "ca_in.columns = [x.replace(\"-\", \"_\") for x in ca_in.columns]\n",
+    "\n",
+    "ca_df = ca_in[ca_in[\"geometry\"].notnull()].copy()\n",
     "\n",
     "# join organisation name and LPA codes from lookup\n",
     "ca_df = ca_df.merge(\n",
@@ -249,17 +238,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "337\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# LPA boundaries from PDP site\n",
     "lpa_gdf = get_pdp_geo_dataset(\"local-planning-authority\")\n",
@@ -278,17 +259,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9275\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# join LPAs to all conservation areas, then join on the names of supplying organisations for matching conservation areas\n",
     "lpa_ca_join = gpd.sjoin(\n",
@@ -310,19 +283,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4112\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "MATCH_LOWER_THRESH = 0.9  # defines the lower limit of the shared overlap between two entities to be called a match\n",
+    "MATCH_LOWER_THRESH = 0.95  # defines the lower limit of the shared overlap between two entities to be called a match\n",
     "EDGE_UPPER_THRESH = 0.1   # defines the upper limit of the shared overlap between two entities to be called an edge intersection\n",
     "EDGE_LOWER_THRESH = 0.01   # defines the lower limit of the shared overlap between two entities to be called an edge intersection\n",
     "\n",
@@ -390,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,17 +387,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "309\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# create subset table with only single instances of each issue\n",
     "overlap_issues_dist = ca_issues_he_lpa.copy()\n",
@@ -457,7 +414,7 @@
     "# add in action field\n",
     "overlap_issues_dist[\"action\"] = np.select(\n",
     "    [\n",
-    "        (overlap_issues_dist[\"intersection_type\"] == \"> 90% combined match\") &\n",
+    "        (overlap_issues_dist[\"intersection_type\"] == \"Complete match (two-way)\") &\n",
     "        (overlap_issues_dist[\"multi_issue_entities\"] == False) \n",
     "\n",
     "    ],\n",
@@ -465,31 +422,49 @@
     "    default = \"investigate\"\n",
     ")\n",
     "\n",
+    "# write report to output dir\n",
     "print(len(overlap_issues_dist))\n",
-    "# overlap_issues_dist.head()"
+    "# overlap_issues_dist.head()\n",
+    "overlap_issues_dist.sort_values([\"organisation_name_1\", \"action\"]\n",
+    "                                ).to_csv(os.path.join(output_dir, f\"conservation_area_duplicates_report_{td}.csv\"), index = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write redirections to output dir\n",
+    "\n",
+    "redirections = overlap_issues_dist[overlap_issues_dist[\"action\"] == \"remap\"]\n",
+    "n_redirects = len(redirections)\n",
+    "\n",
+    "old_entity_update = pd.DataFrame({\n",
+    "    \"old-entity\" : redirections[\"entity_2\"],\n",
+    "    \"status\" : [\"301\"] * n_redirects,\n",
+    "    \"entity\" : redirections[\"entity_1\"],\n",
+    "    \"end-date\" : [\"\"] * n_redirects,\n",
+    "    \"notes\" : [\"redirect Historic England duplicate to LPA entity\"] * n_redirects,\n",
+    "    \"entry-date\" : [td] * n_redirects,\n",
+    "    \"start-date\" : [\"\"] * n_redirects\n",
+    "})\n",
+    "\n",
+    "old_entity_update.to_csv(os.path.join(output_dir, f\"redirections_old-entity-update_{td}.csv\"), index = False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Combine"
+    "### Combine (for mapping)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9275\n",
-      "9275\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Join LPAs with intersecting CAs to CA geometry, and then to CA overlap issues\n",
     "\n",
@@ -515,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,133 +514,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ODP LPAs by number of overlap issues\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>lpa_name</th>\n",
-       "      <th>count</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>Southwark LPA</td>\n",
-       "      <td>96</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>North Somerset LPA</td>\n",
-       "      <td>70</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>East Cambridgeshire LPA</td>\n",
-       "      <td>56</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>St Albans LPA</td>\n",
-       "      <td>27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>Rossendale LPA</td>\n",
-       "      <td>18</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>Sandwell LPA</td>\n",
-       "      <td>18</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Great Yarmouth LPA</td>\n",
-       "      <td>17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>Waverley LPA</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Dorset LPA</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Buckinghamshire LPA</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Leicester LPA</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>Trafford LPA</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>South Norfolk LPA</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                   lpa_name  count\n",
-       "9             Southwark LPA     96\n",
-       "5        North Somerset LPA     70\n",
-       "2   East Cambridgeshire LPA     56\n",
-       "10            St Albans LPA     27\n",
-       "6            Rossendale LPA     18\n",
-       "7              Sandwell LPA     18\n",
-       "3        Great Yarmouth LPA     17\n",
-       "12             Waverley LPA     10\n",
-       "1                Dorset LPA      5\n",
-       "0       Buckinghamshire LPA      4\n",
-       "4             Leicester LPA      4\n",
-       "11             Trafford LPA      3\n",
-       "8         South Norfolk LPA      1"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"ODP LPAs by number of overlap issues\")\n",
     "ODP_overlap_issues_count"
@@ -673,34 +524,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2bcc0ce62bf4ae7a32115d85a0b5e89",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(Dropdown(description='Select LPA:', options={'Southwark LPA': 'Southwark LPA', 'North So…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<function __main__.display_lpa_issues(lpa_name, show_only_issues=False)>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ODP_dataset_options = dict(zip(ODP_overlap_issues_count[\"lpa_name\"], ODP_overlap_issues_count[\"lpa_name\"]))\n",
     "\n",
@@ -721,169 +547,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ODP LPAs by number of overlap issues\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>lpa_name</th>\n",
-       "      <th>count</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>Maldon LPA</td>\n",
-       "      <td>70</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>East Suffolk LPA</td>\n",
-       "      <td>30</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>Mole Valley LPA</td>\n",
-       "      <td>22</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>St. Helens LPA</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>Southend-on-Sea LPA</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Chichester LPA</td>\n",
-       "      <td>7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Calderdale LPA</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>Vale of White Horse LPA</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Cornwall LPA</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>Cumberland LPA</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Carlisle LPA</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>South Oxfordshire LPA</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>The Broads Authority LPA</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>Peak District National Park LPA</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>South Bucks LPA</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>Somerset LPA</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>Sedgemoor LPA</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Chiltern LPA</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>Wycombe LPA</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                           lpa_name  count\n",
-       "7                        Maldon LPA     70\n",
-       "6                  East Suffolk LPA     30\n",
-       "8                   Mole Valley LPA     22\n",
-       "15                   St. Helens LPA     10\n",
-       "14              Southend-on-Sea LPA     10\n",
-       "2                    Chichester LPA      7\n",
-       "0                    Calderdale LPA      6\n",
-       "17          Vale of White Horse LPA      5\n",
-       "4                      Cornwall LPA      4\n",
-       "5                    Cumberland LPA      4\n",
-       "1                      Carlisle LPA      4\n",
-       "13            South Oxfordshire LPA      2\n",
-       "16         The Broads Authority LPA      2\n",
-       "9   Peak District National Park LPA      2\n",
-       "12                  South Bucks LPA      2\n",
-       "11                     Somerset LPA      2\n",
-       "10                    Sedgemoor LPA      2\n",
-       "3                      Chiltern LPA      1\n",
-       "18                      Wycombe LPA      1"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"non-ODP LPAs by number of overlap issues\")\n",
     "nODP_overlap_issues_count"
@@ -891,34 +557,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18ca731acd024724b95c117be6a47ab6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(Dropdown(description='Select LPA:', options={'Maldon LPA': 'Maldon LPA', 'East Suffolk L…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<function __main__.display_lpa_issues(lpa_name, show_only_issues=False)>"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nODP_dataset_options = dict(zip(nODP_overlap_issues_count[\"lpa_name\"], nODP_overlap_issues_count[\"lpa_name\"]))\n",
     "\n",


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Updates the duplicate logic used in the endpoint checker so that the only matches made are those where two entities' polygons both overlap each other >95%. Previously, one way matches were included, which means we could merge entities where one polygon is totally covered by a much larger polygon.

Also updates conservation-area duplicate report to match logic and also output redirections in a format that can be copied directly into `pipeline/conservation-area/old-entity.csv`. 
