### PR TITLE
Add in final entity count analysis notebook and update README

### DIFF
--- a/analysis/2026-03_entity_counts_check/3_final_report_csv.ipynb
+++ b/analysis/2026-03_entity_counts_check/3_final_report_csv.ipynb
@@ -1,0 +1,859 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "938f0e98",
+   "metadata": {},
+   "source": [
+    "# Checking entity counts between Platform data, historic endpoints and transformed resources\n",
+    "**Author**:  Sian Teesdale\n",
+    "\n",
+    "**Date created**: May 2026\n",
+    "\n",
+    "**Dataset Scope**: article-4-direction-area, conservation-area, listed-building-outline, tree, tree-preservation-zone\n",
+    "\n",
+    "**Purpose**: This analysis is to make a comparison report on the entity counts within the Platform and the entity_counts from the dataset_resource. The aim is for us to easily see if there are weird differences that could be a result of us duplicating data on the platform. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3c4fa001",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import json\n",
+    "import urllib.request\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df2640e4",
+   "metadata": {},
+   "source": [
+    "## Process the reporting historic endpoint/dataset resource"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "47a01ee9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save ODP datasets\n",
+    "datasets = ['article-4-direction-area', 'tree', 'tree-preservation-zone', 'listed-building-outline', 'conservation-area']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "280ca866",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fetched 1000 rows...\n",
+      "Fetched 2000 rows...\n",
+      "Fetched 3000 rows...\n",
+      "Fetched 4000 rows...\n",
+      "Fetched 5000 rows...\n",
+      "Fetched 6000 rows...\n",
+      "Fetched 7000 rows...\n",
+      "Fetched 8000 rows...\n",
+      "Fetched 9000 rows...\n",
+      "Fetched 10000 rows...\n",
+      "Fetched 11000 rows...\n",
+      "Fetched 12000 rows...\n",
+      "Fetched 13000 rows...\n",
+      "Fetched 14000 rows...\n",
+      "Fetched 15000 rows...\n",
+      "Fetched 16000 rows...\n",
+      "Fetched 17000 rows...\n",
+      "Fetched 18000 rows...\n",
+      "Fetched 19000 rows...\n",
+      "Fetched 20000 rows...\n",
+      "Fetched 21000 rows...\n",
+      "Fetched 22000 rows...\n",
+      "Fetched 23000 rows...\n",
+      "Fetched 24000 rows...\n",
+      "Fetched 25000 rows...\n",
+      "Fetched 26000 rows...\n",
+      "Fetched 27000 rows...\n",
+      "Fetched 27765 rows...\n",
+      "Total: 27765 rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_rows = []\n",
+    "last_rowid = 0\n",
+    "\n",
+    "while True:\n",
+    "    if last_rowid == 0:\n",
+    "        # First batch: no filter\n",
+    "        url = \"https://datasette.planning.data.gov.uk/performance/reporting_historic_endpoints.json?_shape=array&_size=max\"\n",
+    "    else:\n",
+    "        # Subsequent batches: filter by rowid__gt\n",
+    "        url = f\"https://datasette.planning.data.gov.uk/performance/reporting_historic_endpoints.json?_shape=array&_size=max&rowid__gt={last_rowid}\"\n",
+    "    \n",
+    "    response = urllib.request.urlopen(url, timeout=120)\n",
+    "    rows = json.load(response)\n",
+    "    \n",
+    "    if not rows:\n",
+    "        break\n",
+    "    \n",
+    "    all_rows.extend(rows)\n",
+    "    last_rowid = rows[-1]['rowid']\n",
+    "    print(f\"Fetched {len(all_rows)} rows...\")\n",
+    "    \n",
+    "    if len(rows) < 1000:\n",
+    "        break\n",
+    "\n",
+    "report_he = pd.DataFrame(all_rows)\n",
+    "print(f\"Total: {len(report_he)} rows\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9a6edb2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove inactive endpoints and filter for only the ODP datasets \n",
+    "report_he = report_he.loc[(report_he['dataset'].isin(datasets)) & (report_he['resource_end_date'] == '')]\n",
+    "\n",
+    "# WARNING: merging `report_he` directly to `data_resource` can inflate counts\n",
+    "# if `report_he` contains multiple rows for the same resource. In that case\n",
+    "# the same dataset_resource.entity_count is repeated and then summed more than once.\n",
+    "#\n",
+    "# To avoid that, reduce `report_he` to one row per resource before the merge.\n",
+    "report_he = report_he.drop_duplicates(subset=['resource', 'dataset']).copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dded1fab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'e3eb3651fdb452b7396dbf901df1f54324971d25b71355e6a5f13309a69dfc81'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "report_he.loc[(report_he['dataset'] == 'article-4-direction-area') & (report_he['name'] == 'London Borough of Barking and Dagenham')]['resource'].item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5a6d1834",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Loop over and get the dataset_resource for each dataset, then concatenate into a single dataframe\n",
+    "dfs = []\n",
+    "for data in datasets:\n",
+    "    df = pd.read_csv(f'https://datasette.planning.data.gov.uk/{data}/dataset_resource.csv?_stream=on')\n",
+    "    dfs.append(df)\n",
+    "\n",
+    "data_resource = pd.concat(dfs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "18d711bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testing = pd.merge(report_he, data_resource[['dataset', 'resource', 'entity_count', 'entry_count', 'line_count']], on=['dataset', 'resource'])\n",
+    "\n",
+    "# Groupby to get entity-count per LPA\n",
+    "dataset_resource_entity_count = testing.groupby(['dataset', 'name', 'organisation'])[['entity_count', 'entry_count', 'line_count']].sum().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "690a7bad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the entity and resource counts per LPA in each dataset\n",
+    "entity_resource_counts = testing.groupby(['dataset', 'name', 'organisation'])[['endpoint', 'resource']].count().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f386d26f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>rowid</th>\n",
+       "      <th>organisation</th>\n",
+       "      <th>name</th>\n",
+       "      <th>organisation_name</th>\n",
+       "      <th>dataset</th>\n",
+       "      <th>collection</th>\n",
+       "      <th>pipeline</th>\n",
+       "      <th>endpoint</th>\n",
+       "      <th>endpoint_url</th>\n",
+       "      <th>documentation_url</th>\n",
+       "      <th>...</th>\n",
+       "      <th>latest_exception</th>\n",
+       "      <th>resource</th>\n",
+       "      <th>latest_log_entry_date</th>\n",
+       "      <th>endpoint_entry_date</th>\n",
+       "      <th>endpoint_end_date</th>\n",
+       "      <th>resource_start_date</th>\n",
+       "      <th>resource_end_date</th>\n",
+       "      <th>entity_count</th>\n",
+       "      <th>entry_count</th>\n",
+       "      <th>line_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>215</th>\n",
+       "      <td>9552</td>\n",
+       "      <td>local-authority:BNE</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>article-4-direction</td>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>d4c09389082ca55e33cf532eb045ea7eb9dc447a24547f...</td>\n",
+       "      <td>https://open.barnet.gov.uk/download/e5l77/dhv/...</td>\n",
+       "      <td>https://open.barnet.gov.uk/dataset/e5l77/artic...</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td>2702f238b05ec028cbd33738b718a81ba9fc70680f1e6f...</td>\n",
+       "      <td>2026-05-21</td>\n",
+       "      <td>2023-12-18</td>\n",
+       "      <td></td>\n",
+       "      <td>2024-07-17</td>\n",
+       "      <td></td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>48</td>\n",
+       "      <td>49</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>216</th>\n",
+       "      <td>9575</td>\n",
+       "      <td>local-authority:BNE</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>conservation-area</td>\n",
+       "      <td>conservation-area</td>\n",
+       "      <td>conservation-area</td>\n",
+       "      <td>1cafec4102c43a9e95f54bd36453240251c7741d7d15de...</td>\n",
+       "      <td>https://open.barnet.gov.uk/download/20yo8/c6n/...</td>\n",
+       "      <td>https://open.barnet.gov.uk/dataset/20yo8/conse...</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td>622b7161f695d63420100a288b72d11b7113ca5e987e79...</td>\n",
+       "      <td>2026-05-21</td>\n",
+       "      <td>2023-11-06</td>\n",
+       "      <td></td>\n",
+       "      <td>2025-03-21</td>\n",
+       "      <td></td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>16</td>\n",
+       "      <td>17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>217</th>\n",
+       "      <td>9584</td>\n",
+       "      <td>local-authority:BNE</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>listed-building-outline</td>\n",
+       "      <td>listed-building</td>\n",
+       "      <td>listed-building-outline</td>\n",
+       "      <td>6cec4fa5b9e9340c4f594bbdbac5cd7ffaf94498583d1c...</td>\n",
+       "      <td>https://open.barnet.gov.uk/download/2w6jz/ztc/...</td>\n",
+       "      <td>https://open.barnet.gov.uk/dataset/2w6jz/statu...</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td>1fb9fa7a23719e76fc5f55971d2ffa95e92fc705a0450a...</td>\n",
+       "      <td>2026-05-21</td>\n",
+       "      <td>2023-12-18</td>\n",
+       "      <td></td>\n",
+       "      <td>2026-05-02</td>\n",
+       "      <td></td>\n",
+       "      <td>651.0</td>\n",
+       "      <td>651</td>\n",
+       "      <td>652</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>218</th>\n",
+       "      <td>9613</td>\n",
+       "      <td>local-authority:BNE</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>tree</td>\n",
+       "      <td>tree-preservation-order</td>\n",
+       "      <td>tree</td>\n",
+       "      <td>422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51...</td>\n",
+       "      <td>https://open.barnet.gov.uk/download/e5nge/837/...</td>\n",
+       "      <td>https://open.barnet.gov.uk/dataset/e5nge/tree-...</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td>98681061fb9aca798fa2a294a2720ac97321c7ff5642e7...</td>\n",
+       "      <td>2026-05-21</td>\n",
+       "      <td>2023-11-07</td>\n",
+       "      <td></td>\n",
+       "      <td>2026-05-02</td>\n",
+       "      <td></td>\n",
+       "      <td>6181.0</td>\n",
+       "      <td>6181</td>\n",
+       "      <td>9392</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>219</th>\n",
+       "      <td>9677</td>\n",
+       "      <td>local-authority:BNE</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>London Borough of Barnet</td>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>tree-preservation-order</td>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51...</td>\n",
+       "      <td>https://open.barnet.gov.uk/download/e5nge/837/...</td>\n",
+       "      <td>https://open.barnet.gov.uk/dataset/e5nge/tree-...</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td>98681061fb9aca798fa2a294a2720ac97321c7ff5642e7...</td>\n",
+       "      <td>2026-05-21</td>\n",
+       "      <td>2023-11-07</td>\n",
+       "      <td></td>\n",
+       "      <td>2026-05-02</td>\n",
+       "      <td></td>\n",
+       "      <td>3210.0</td>\n",
+       "      <td>3210</td>\n",
+       "      <td>9392</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 22 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     rowid         organisation                      name  \\\n",
+       "215   9552  local-authority:BNE  London Borough of Barnet   \n",
+       "216   9575  local-authority:BNE  London Borough of Barnet   \n",
+       "217   9584  local-authority:BNE  London Borough of Barnet   \n",
+       "218   9613  local-authority:BNE  London Borough of Barnet   \n",
+       "219   9677  local-authority:BNE  London Borough of Barnet   \n",
+       "\n",
+       "            organisation_name                   dataset  \\\n",
+       "215  London Borough of Barnet  article-4-direction-area   \n",
+       "216  London Borough of Barnet         conservation-area   \n",
+       "217  London Borough of Barnet   listed-building-outline   \n",
+       "218  London Borough of Barnet                      tree   \n",
+       "219  London Borough of Barnet    tree-preservation-zone   \n",
+       "\n",
+       "                  collection                  pipeline  \\\n",
+       "215      article-4-direction  article-4-direction-area   \n",
+       "216        conservation-area         conservation-area   \n",
+       "217          listed-building   listed-building-outline   \n",
+       "218  tree-preservation-order                      tree   \n",
+       "219  tree-preservation-order    tree-preservation-zone   \n",
+       "\n",
+       "                                              endpoint  \\\n",
+       "215  d4c09389082ca55e33cf532eb045ea7eb9dc447a24547f...   \n",
+       "216  1cafec4102c43a9e95f54bd36453240251c7741d7d15de...   \n",
+       "217  6cec4fa5b9e9340c4f594bbdbac5cd7ffaf94498583d1c...   \n",
+       "218  422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51...   \n",
+       "219  422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51...   \n",
+       "\n",
+       "                                          endpoint_url  \\\n",
+       "215  https://open.barnet.gov.uk/download/e5l77/dhv/...   \n",
+       "216  https://open.barnet.gov.uk/download/20yo8/c6n/...   \n",
+       "217  https://open.barnet.gov.uk/download/2w6jz/ztc/...   \n",
+       "218  https://open.barnet.gov.uk/download/e5nge/837/...   \n",
+       "219  https://open.barnet.gov.uk/download/e5nge/837/...   \n",
+       "\n",
+       "                                     documentation_url  ... latest_exception  \\\n",
+       "215  https://open.barnet.gov.uk/dataset/e5l77/artic...  ...                    \n",
+       "216  https://open.barnet.gov.uk/dataset/20yo8/conse...  ...                    \n",
+       "217  https://open.barnet.gov.uk/dataset/2w6jz/statu...  ...                    \n",
+       "218  https://open.barnet.gov.uk/dataset/e5nge/tree-...  ...                    \n",
+       "219  https://open.barnet.gov.uk/dataset/e5nge/tree-...  ...                    \n",
+       "\n",
+       "                                              resource latest_log_entry_date  \\\n",
+       "215  2702f238b05ec028cbd33738b718a81ba9fc70680f1e6f...            2026-05-21   \n",
+       "216  622b7161f695d63420100a288b72d11b7113ca5e987e79...            2026-05-21   \n",
+       "217  1fb9fa7a23719e76fc5f55971d2ffa95e92fc705a0450a...            2026-05-21   \n",
+       "218  98681061fb9aca798fa2a294a2720ac97321c7ff5642e7...            2026-05-21   \n",
+       "219  98681061fb9aca798fa2a294a2720ac97321c7ff5642e7...            2026-05-21   \n",
+       "\n",
+       "    endpoint_entry_date endpoint_end_date resource_start_date  \\\n",
+       "215          2023-12-18                            2024-07-17   \n",
+       "216          2023-11-06                            2025-03-21   \n",
+       "217          2023-12-18                            2026-05-02   \n",
+       "218          2023-11-07                            2026-05-02   \n",
+       "219          2023-11-07                            2026-05-02   \n",
+       "\n",
+       "    resource_end_date entity_count entry_count  line_count  \n",
+       "215                           48.0          48          49  \n",
+       "216                           16.0          16          17  \n",
+       "217                          651.0         651         652  \n",
+       "218                         6181.0        6181        9392  \n",
+       "219                         3210.0        3210        9392  \n",
+       "\n",
+       "[5 rows x 22 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check Barnet has the duplicated resource for both Tree and TPZ (which is correct)\n",
+    "testing.loc[testing['name'].str.contains('Barnet')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba5b87b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Detailed endpoint/resource CSV \n",
+    "detailed_dataset_resource_entity_count = testing.groupby(['dataset', 'name', 'organisation', 'endpoint', 'endpoint_entry_date', 'resource', 'resource_start_date'])[['entity_count', 'entry_count', 'line_count']].sum().reset_index()\n",
+    "\n",
+    "# Save to CSV\n",
+    "detailed_dataset_resource_entity_count.to_csv('dataset_resource_odp_detailed_counts.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2bf5ce6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "resource\n",
+       "ef2236d310cfdec35d754d13b8e4599d131102393e6bba716291ddb5cc993221    2\n",
+       "3c004d5128a298afc4960c5d74cbe16d55eb2eade6fe42b9b664be36a978ab89    2\n",
+       "98681061fb9aca798fa2a294a2720ac97321c7ff5642e7a64321bf1ab192c092    2\n",
+       "a15236ae19de583cf0782aa3df8cca5d74bcfb5c5c201c01ce70ab0671a8a2a6    2\n",
+       "66b6ee34f1666ef022ca9d52d7f12707d7b0b38ca1040b9c71a14d8d480bb58d    1\n",
+       "                                                                   ..\n",
+       "92c30cdae7169d831a3f52b3ffb2b877d5d562bb9bbe377e9f09353f03b0301b    1\n",
+       "2b5bc568417092f67af1ba67256614b153a6cbc589daa3545ff838838d253a7a    1\n",
+       "a0304351e90bfd06f7de89ccb7bd2c37cb2260fc53ab5e44b7f6a718cd29648a    1\n",
+       "3a706aa35784ec838a0635faf771c8d333f243d5bea9b64f2d3f9fa8bbf70992    1\n",
+       "f2abec8547d4abbfc8a8332fda9c7db6790eb2aa123dba1de7b033e9348d75be    1\n",
+       "Name: count, Length: 605, dtype: int64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# How many resources appear more than once?\n",
+    "detailed_dataset_resource_entity_count['resource'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "994d5c1d",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5ded4db",
+   "metadata": {},
+   "source": [
+    "## Process the platform data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f8950663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "organisation = pd.read_csv('https://datasette.planning.data.gov.uk/digital-land/organisation.csv?_labels=on&_size=max')\n",
+    "\n",
+    "organisation = organisation[['entity', 'organisation', 'name']].rename(columns={'entity':'organisation-entity', \n",
+    "                                                                                'name':'organisation-name',\n",
+    "                                                                                'organisation':'organisation-code'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f313451a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/ff/zpylthrn3877kx4h8lxvsvjm0000gn/T/ipykernel_13977/3044584250.py:5: DtypeWarning: Columns (14,16,17,22,24) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  df = pd.read_csv(url)\n",
+      "/var/folders/ff/zpylthrn3877kx4h8lxvsvjm0000gn/T/ipykernel_13977/3044584250.py:5: DtypeWarning: Columns (15,21) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  df = pd.read_csv(url)\n",
+      "/var/folders/ff/zpylthrn3877kx4h8lxvsvjm0000gn/T/ipykernel_13977/3044584250.py:5: DtypeWarning: Columns (14,15,19) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  df = pd.read_csv(url)\n"
+     ]
+    }
+   ],
+   "source": [
+    "dfs = []\n",
+    "\n",
+    "for data in datasets:\n",
+    "    url = f'https://files.planning.data.gov.uk/dataset/{data}.csv'\n",
+    "    df = pd.read_csv(url)\n",
+    "    dfs.append(df)\n",
+    "\n",
+    "platform_data = pd.concat(dfs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "91a69422",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "platform_data = pd.merge(platform_data, organisation, on='organisation-entity', how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "52063357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "platform_entity_count = platform_data.groupby(['dataset', 'organisation-name', 'organisation-code']).size().to_frame('platform_entity_count').reset_index()\\\n",
+    "                                     .rename(columns={'organisation-name':'name', 'organisation-code':'organisation'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6ed2f520",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dataset</th>\n",
+       "      <th>name</th>\n",
+       "      <th>organisation</th>\n",
+       "      <th>platform_entity_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>Adur District Council</td>\n",
+       "      <td>local-authority:ADU</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>Ashford Borough Council</td>\n",
+       "      <td>local-authority:ASF</td>\n",
+       "      <td>75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>Birmingham City Council</td>\n",
+       "      <td>local-authority:BIR</td>\n",
+       "      <td>13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>Blackpool Borough Council</td>\n",
+       "      <td>local-authority:BPL</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>article-4-direction-area</td>\n",
+       "      <td>Bristol City Council</td>\n",
+       "      <td>local-authority:BST</td>\n",
+       "      <td>16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>620</th>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>Thanet District Council</td>\n",
+       "      <td>local-authority:THA</td>\n",
+       "      <td>677</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>621</th>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>Torbay Council</td>\n",
+       "      <td>local-authority:TOB</td>\n",
+       "      <td>836</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>622</th>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>West Berkshire Council</td>\n",
+       "      <td>local-authority:WBK</td>\n",
+       "      <td>1115</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>623</th>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>Wirral Borough Council</td>\n",
+       "      <td>local-authority:WRL</td>\n",
+       "      <td>2499</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>624</th>\n",
+       "      <td>tree-preservation-zone</td>\n",
+       "      <td>Worthing Borough Council</td>\n",
+       "      <td>local-authority:WOT</td>\n",
+       "      <td>1287</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>625 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      dataset                       name         organisation  \\\n",
+       "0    article-4-direction-area      Adur District Council  local-authority:ADU   \n",
+       "1    article-4-direction-area    Ashford Borough Council  local-authority:ASF   \n",
+       "2    article-4-direction-area    Birmingham City Council  local-authority:BIR   \n",
+       "3    article-4-direction-area  Blackpool Borough Council  local-authority:BPL   \n",
+       "4    article-4-direction-area       Bristol City Council  local-authority:BST   \n",
+       "..                        ...                        ...                  ...   \n",
+       "620    tree-preservation-zone    Thanet District Council  local-authority:THA   \n",
+       "621    tree-preservation-zone             Torbay Council  local-authority:TOB   \n",
+       "622    tree-preservation-zone     West Berkshire Council  local-authority:WBK   \n",
+       "623    tree-preservation-zone     Wirral Borough Council  local-authority:WRL   \n",
+       "624    tree-preservation-zone   Worthing Borough Council  local-authority:WOT   \n",
+       "\n",
+       "     platform_entity_count  \n",
+       "0                        9  \n",
+       "1                       75  \n",
+       "2                       13  \n",
+       "3                        6  \n",
+       "4                       16  \n",
+       "..                     ...  \n",
+       "620                    677  \n",
+       "621                    836  \n",
+       "622                   1115  \n",
+       "623                   2499  \n",
+       "624                   1287  \n",
+       "\n",
+       "[625 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "platform_entity_count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29f2fc00",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "788f65a4",
+   "metadata": {},
+   "source": [
+    "## Merge together and compare"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "041d3144",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Merge the two dataframes to get the count of resource/endpoints as well as the sum of entity/entry/line counts for each dataset/LPA/organisation\n",
+    "dataset_resource_entity_count_final = pd.merge(dataset_resource_entity_count, entity_resource_counts, on=['dataset', 'name', 'organisation'], how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67b2b88e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Merge the platform entity count with the dataset_resource entity count and resource counts to get a final dataframe for analysis\n",
+    "merged_df = pd.merge(platform_entity_count, dataset_resource_entity_count_final, on=['dataset', 'name', 'organisation'], how='outer')\n",
+    "merged_df.rename(columns={'entity_count':'dataset_resource_entity_count', \n",
+    "                          'entry_count':'dataset_resource_entry_count', \n",
+    "                          'line_count':'dataset_resource_line_count', \n",
+    "                          'endpoint':'dataset_resource_endpoint_count', \n",
+    "                          'resource':'dataset_resource_resource_count'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a5c9d7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Divide the platform entity count by the dataset_resource line count to get a ratio of how many entities are on the platform per line in the dataset_resource\n",
+    "# Note: We chose line count because of potential erroneous entity counts in the dataset_resource (displaying 0s/NaNs)\n",
+    "merged_df['platform_divided_by_dr_line_count'] = merged_df['platform_entity_count'] / merged_df['dataset_resource_line_count']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96b6a7f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to CSV\n",
+    "merged_df.to_csv('dataset_resource_vs_platform_odp_summary.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ba81149",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[<Axes: title={'center': 'platform_divided_by_dr_line_count'}>]],\n",
+       "      dtype=object)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAigAAAGzCAYAAAAFROyYAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOg5JREFUeJzt3QucTfX+//HPzBjjTkYMueRSuV+ipFRyDT8R5/y6SCqHk+iEjsRBMySO069SiVNHOL/SRSeK5B5+jpFbyqUjpKgwlcNgMsbM+j8+399v7f/eewazp7l81/J6Ph7Ltvdas/f6ru++vPf3snaU4ziOAAAAWCS6qHcAAAAgHAEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQVWuPLKK+WBBx7I9/v97//+b6lfv77ExsZKhQoVxOsSExMlKioqX47dnDlzzH198803hV4/+pj62LoPubVmzRrzN++9957YWA+/hh5bPcbB9P71cYBLFQEFnvbDDz+YN/Ht27dnW/evf/3LvPHXrVtXXnvtNXn11VeLZB8BFIy0tDTz+tfwCv8pVtQ7APzagJKUlGS+fTZv3jxknb5pZWVlybRp06RevXq+PdB79uyR6OjIv2v069dP7r77bomLiyuQ/cKv88svv0ixYrxFXyyg6OtftWvXjqecz9CCAt9KSUkxl/nZtaNviLbRgKFdWJGKiYmREiVK5GtXBf4/DcdnzpzJ8yHRuiGg4FJGQEGh9NVrd8t//ud/Srly5SQ+Pl4ee+yxC755Hzt2TP74xz9KkyZNpEyZMubvunbtKp9//nlIC8l1111n/v/ggw+ax3HHNWiLylNPPWXWXX755dn681955RVp1KiR+XCvVq2aDBkyRI4fPx6yD/qNrHHjxrJ161a55ZZbpFSpUjJmzJjA+Ilnn31Wpk+fLnXq1DHrOnfuLIcOHRL9gfCJEydK9erVpWTJktKzZ09TnkitX7/elE8/qLSb6q9//etFx4ds2bLF7NvcuXOzbbds2TKzbvHixecdg6L7/vTTT5t91zLddtttsmvXrhwfV4/XsGHDpEaNGuY4aivVn//8Z/PBHL6d7l/58uVNWOzfv3+2Yx2JzMxMUw8JCQlSunRpueOOO8xxd2m9a2D78ccfs/3toEGDzD5EEhxyWw96LIcOHSpvvvlm4Lm1dOnSPJYy+xgU97W0b98+czy1HHpM9bmfU3B+4403pGXLluY5WLFiRdNaFnycckvravjw4eZ5pmXS58b9998vP/30U8iXgQEDBkiVKlXMcWrWrFm256A7hii8Oyan8UhaPn3df//999KrVy/zf30d63uC1r/7d3qb0lYU9/XPuB3/oP0QhULDib7BTZ48WTZu3Cgvvvii/Pvf/5a///3vOW7/9ddfy8KFC+W3v/2t1K5dW44ePWo+GG699VbZvXu3CRUNGjSQCRMmyPjx480Hz80332z+9sYbb5QXXnjB3PeCBQtkxowZ5g2uadOmZr2+gekbWseOHWXw4MGmi0S32bx5s/zzn/8MaY34+eefTTDSN/f77rvPvAG79IPo7Nmz8uijj5oAMnXqVFPO9u3bmzfhUaNGmQ+Tl156ybyxvv7667k+Xjt27DCBR9+AdX/PnTtnPniDHz8nrVq1MoHp3XffNUEg2DvvvCOXXXaZdOnS5bx/r8dSA0q3bt3Msm3bNrMfWs5g+oGodaEfIL///e+lZs2asmHDBhk9erQcPnzYHH838GhA0w/5hx9+2NSZ1kn4vkVi0qRJ5oNIj69+MOpjaV3qOCT9MNauK31eaHk1MLi0DDrAtk+fPuZDtCDqYfXq1ebY6+NWqlQp28DX/KDPMX1N6GtJ6+dvf/ubVK5c2YTD4GM0btw4s+3vfvc7E9b0eahB+7PPPst1q+KpU6fM6+rLL7+Uhx56SK699loTTD788EP57rvvTBm1K0rDvD7Xtdy6b/PnzzchQ8ONfhnJCw0i+lxt3bq1+TKwcuVK+a//+i8TEvV1q3Wir1v9/5133im9e/c2f+e+zuEDDlCAnnrqKUefZnfccUfI7Y888oi5/fPPPzfXa9Wq5fTv3z+w/syZM05mZmbI3xw4cMCJi4tzJkyYELht8+bN5n5mz5593sf+8ccfA7elpKQ4xYsXdzp37hxy/y+//LLZ9vXXXw/cduutt5rbZs6cmW0/9PbLL7/cOX78eOD20aNHm9ubNWvmZGRkBG6/5557zGNqmXKrV69eTokSJZxvv/02cNvu3budmJgY8xjBwo+d7kdsbKxz7NixwG3p6elOhQoVnIceeihwmx4zvS8tT/Cx6d69u5OVlRXYbsyYMWa74MeYOHGiU7p0aeerr74K2Zcnn3zS7OPBgwfN9YULF5q/nTp1amCbc+fOOTfffPN56+18PvnkE/M3V1xxhZOamhq4/d133zW3T5s2LXBbmzZtnNatW4f8/fvvv2+20/spiHrQ69HR0c6uXbucSOmx1XoMvz99Doc/n4PrUN15551OfHx84Po333xj9m/SpEkh2+3YscMpVqxYttsvZPz48eYx9diFc58jL7zwgtnmjTfeCKw7e/asqYMyZcoE6sqtv/Dj776egp8Lejz0tuDXumrRooXTsmXLwHV9bYcfJ/gHXTwoFNqFEkxbHdSSJUty3F6bkt2Bn/pNSlsytBXkmmuuMd8a80q/hek3ae2aCB5YOnDgQNON9NFHH2XbD21Cz4m27mgTu0u/6SltaQkeO6C362Nqa0NuaHm1O0abtrVlwqWtDxdq/XDdddddkpGRIe+//37gtuXLl5tvs7ruYsdG6yZ4XIoeq3D6DVm/WWuLjH6jdhdtydD9X7duXaB+9Vjot9zgsS9u/eeFdi+ULVs2cP03v/mNVK1aNeS5pNt8+umnsn///pAWL+2O0pafgqoHve+GDRtKQdKWqGBaD/r6SE1NNde13rWbTVtPgutGu8Suuuoq+eSTT3L9WP/4xz9Md422UIRznyN63PW+77nnnsA6bYX8wx/+YFpg1q5dm69l1dZVXBoIKCgU+sYYTJtpNSCc7xwc+gb7/PPPm7/TkKBNydqk+8UXX8iJEyfyvB/ffvutudSgE6x48eKma8Rd77riiivMupwEf2gpN6zoh2BOt2uXVm5oc7w2m4cfs5z2Oyf6gaLnftEuDpf+X4+hdj+dj1v28MfV465BJNjevXvN+ApdF7xoQAkeoKz3qeFBw2Wk5Tif8P3TD0od/xL8XNIgps8bDSVKnzM69qZv3765HhScl3rQ7o2CFv68c+vGfX5p3WgDjO53eP1oV41bN7mhAU/HYV2I1rE+VvhMMg1y7vq80G44d4xJcFlz+zqC9zEGBUXiYh8SzzzzjOlD135vHXCqg/z0DVC/zYcPwixIOqbhfLQlIJLb/7fVvnDoB7SOQ9BvztraoGMG9Btufs0K0Tro1KmTPPHEEzmuv/rqq6Uo6QfZf/zHf5iAouNqdOxJenq6ad0qqudLfrnY80vrRl9fH3/8cY7bhofFon7Nu4Nec1tOXDoIKCgU+q0u+NulDqjTN9LzDSLUDxSdQTJr1qyQ27WbQlsCXJFOka1Vq5a51IGx2mLi0q6NAwcOBFoAipJ+a9QPOj1m4XS/cxtQdCCwNtHrgE5t/teBvrk5Nvq4wcdGWxLCv7VqC5g231/seOl9rlq1ymwb/MGY23LkJPy46AezPp/CB0dqN48O0NXBzxpUWrRoYWbXFGY9FAWtGz0m+nr7tUFR72vnzp0XrWNt2dTXc3Aris7cc9cHt/SEz+DKawuLYoq8v9HFg0Kh03GD6YwCpTNkzvftKbzFQcc9hI/j0GmmKrfTVvUDVbtsdBZR8P1rENJugO7du0tR07LrGAedxXTw4MHA7do8r2MickOb13WKtnbt6KLdLDqD42LHRscOaN0EHxt3Rk4wHd+QnJyc4/5oXehsF6UzgfT/Otsi+BuzW/95obOzTp48GRJmdeZQ+HNJr2uY1dktOg4i0taT/KiHoqCzWXTfNaCGv4b0uo5XyS2d8aRT+3XmVTj3vrWOjxw5EtKlqHWudayh1B3zo0FF98sdnxQ85T+vdCq8+jXT1mEvWlBQKLR1Qs9Xcfvtt5sPNj1Hw7333mvGS+REm+d1qqgOUNVpwzrdU78FB3+zd7/h6ZTJmTNnmq4MDSw6KPV8YwH0W7FOhdU3b90X3Sf9Nqxvknqui4LuAsgt3T8d46GDAh955JHAG762AOi31dy2omj3hvbl6zkqLna2Wfc8Ezp9VY+/fvDolFTtKghutVIjR4403Ua6nU4n1fNtnD592tSTBgYdD6J/06NHD7npppvkySefNLfpAFIdxPlrxhFpd1/btm3Nc0Onn2uA0jEoOtA5mIYtbTV6+eWXzQdj8CDOwqyHwqavCZ0qrs9zPeY6yFdfG/oa1KChU/K1nnND61nrUweEa3er1rNOqde619ecvn71/vQUAPo80HMGaauo/o1O2de6cQc061gsvR89ftryofup44IiGRMTTlu49Dml4Uhbi/S5oWNmLjZuBh5R1NOI4G/u1Eidmvmb3/zGKVu2rHPZZZc5Q4cOdX755ZfAdjlNM3788cedqlWrOiVLlnRuuukmJzk52Uz91SXYBx984DRs2NBMoQyerpjTNOPgacX169c303GrVKniDB482Pn3v/8dso0+TqNGjbL9rTst8i9/+UvI7e40yvnz54fc7k7n1SnRkVi7dq2ZUqlTf+vUqWOmO7tlChZ+7Fx79+412+qyfv36bOvDpxkrnXqdlJQUOO7t2rVzdu7cmeNjnDx50kxprlevntnHSpUqOTfeeKPz7LPPmmmmrp9//tnp16+fU65cOad8+fLm/5999lmepxm/9dZb5nErV65s9lGnRQdPAw62adMm8zc6rTyvclsPen3IkCF5eoxIphmHP59zqkf1j3/8w2nbtq2ZDq6LPt91//bs2RPRvmn96etVp3frMahevbrZ359++imwzdGjR50HH3zQPAd0myZNmuRYt7rvffr0cUqVKmXeB37/+9+b51dO04x1n8PldNw3bNgQqB+mHPtLlP5T1CEJ/uWeFE3HMYR/CwcKmnZP6G80abeQnsANgHcwBgWAb+mvWOs4CPcsowC8gzEoQCHS2Sy6XGwsyKU0xVJnUF3st4p0/EIkU3gXLVpkfhLh1VdfNadfdwdTF3Y9aLnCfyYgmN5/+Lk+CoOe3+Vi44B0PMf5zgEEFIqi7mOCv11oHMilfDwutISPJfA7d2zJhZZIxqooHc+hp6jv2bNnyGnxC7se3J9LON8SPu6ksLjjVi60RPKTAEBBYAwKUIj0NN0XO1W3zlDJ7Y/Z+YGeY0Vnf1yIzprRqdJeqwct14XOfKqtQjrLqbDptOzz/Uq1S2fshJ9BGChMBBQAAGAdBskCAADreHKQrJ5S+YcffjAnAOJUxwAAeIOe2UTPBF2tWrWLnjzSkwFFw0n4L8YCAABvOHTokFSvXt1/AcU9dbIWsFy5cvl63xkZGbJ8+XLp3LmzOVW2n/i5bIryeRd1521+rj8/l60oyqc/XKoNDO7nuO8Cituto+GkIAKK/gCV3q/fnox+LpuifN5F3Xmbn+vPz2UryvLlZngGg2QBAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAPwVUKZMmWKmCg0bNixw25kzZ2TIkCESHx8vZcqUkT59+sjRo0dD/u7gwYPSvXt3M7WpcuXKMnLkSDl37tyv2RUAAOAjeQ4omzdvlr/+9a/StGnTkNuHDx8uixYtkvnz58vatWvNWV979+4dWJ+ZmWnCydmzZ2XDhg0yd+5cmTNnjowfP/7XlQQAAFzaAeXUqVPSt29fee2110J+jvvEiRMya9Ysee6556R9+/bm57pnz55tgsjGjRvNNnrGut27d8sbb7whzZs3l65du8rEiRNl+vTpJrQAAADk6Uyy2oWjrSAdO3aUp59+OnD71q1bzVnp9HZX/fr1pWbNmpKcnCw33HCDuWzSpIlUqVIlsE2XLl1k8ODBsmvXLmnRokW2x0tPTzdL8KlylT6WLvnJvb/8vl8b+LlsivJ5F3XnbX6uPz+XrSjKF8njRBxQ3n77bdm2bZvp4gl35MgRKV68uFSoUCHkdg0jus7dJjicuOvddTmZPHmyJCUlZbtdW2N0HEtBWLFihfiVn8umKJ93UXfe5uf683PZCrN8aWlpBRNQ9Mf5HnvsMVOQEiVKSGEZPXq0jBgxItuPDemPGxXEb/Fo+Tp16uS7313wc9kU5fMu6s7b/Fx/fi5bUZTP7QHJ94CiXTgpKSly7bXXhgx6Xbdunbz88suybNkyM47k+PHjIa0oOosnISHB/F8vN23aFHK/7iwfd5twcXFxZgmnB7OgDmhB3ndR83PZFOXzLurO2/xcf34uW2GWL5LHiGiQbIcOHWTHjh2yffv2wNKqVSszYNb9vz74qlWrAn+zZ88eM624TZs25rpe6n1o0HFpetOWkIYNG0ayOwAAwKciakEpW7asNG7cOOS20qVLm3OeuLcPGDDAdMdUrFjRhI5HH33UhBIdIKu0W0aDSL9+/WTq1Klm3MnYsWPNwNucWkmKSuPEZZKeefGfg7bFN1O6F/UuAABQtLN4LuT555+X6Ohoc4I2nXmjM3ReeeWVwPqYmBhZvHixmbWjwUUDTv/+/WXChAn5vSsAAOBSDShr1qwJua6DZ/WcJrqcT61atWTJkiW/9qEBAIBP8Vs8AADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAODtgDJjxgxp2rSplCtXzixt2rSRjz/+OLC+Xbt2EhUVFbI8/PDDIfdx8OBB6d69u5QqVUoqV64sI0eOlHPnzuVfiQAAgOcVi2Tj6tWry5QpU+Sqq64Sx3Fk7ty50rNnT/nss8+kUaNGZpuBAwfKhAkTAn+jQcSVmZlpwklCQoJs2LBBDh8+LPfff7/ExsbKM888k5/lAgAAl0pA6dGjR8j1SZMmmVaVjRs3BgKKBhINIDlZvny57N69W1auXClVqlSR5s2by8SJE2XUqFGSmJgoxYsXz/Hv0tPTzeJKTU01lxkZGWbJT+79xUU74iW5OQ7uNvl9zGxB+byLuvM2P9efn8tWFOWL5HGiHG0KyQNtDZk/f77079/ftKA0bNjQdPHs2rXLtK5oSNFAM27cuEAryvjx4+XDDz+U7du3B+7nwIEDUqdOHdm2bZu0aNEix8fS8JKUlJTt9nnz5oW00AAAAHulpaXJvffeKydOnDBDRfKtBUXt2LHDjD05c+aMlClTRhYsWGDCidIHrVWrllSrVk2++OIL0zKyZ88eef/99836I0eOmJaTYO51XXc+o0ePlhEjRoS0oNSoUUM6d+580QLmJd2tWLFCxm2JlvSsKPGKnYldcl22Tp06mW41v6F83kXdeZuf68/PZSuK8rk9ILkRcUC55pprTAuIpp/33nvPtKCsXbvWhJRBgwYFtmvSpIlUrVpVOnToIPv375e6detKXsXFxZklnB7MgjqgGk7SM70TUCI5DgV53GxA+byLuvM2P9efn8tWmOWL5DEinmas40Tq1asnLVu2lMmTJ0uzZs1k2rRpOW7bunVrc7lv3z5zqd0+R48eDdnGvX6+cSsAAODS86vPg5KVlRUygDWYO9ZEW1KUdg1pF1FKSkpgG21a0m4at5sIAAAgoi4eHQvStWtXqVmzppw8edIMUl2zZo0sW7bMdOPo9W7dukl8fLwZgzJ8+HC55ZZbzLlTlI4Z0SDSr18/mTp1qhl3MnbsWBkyZEiOXTgAAODSFFFA0ZYPPW+Jnr+kfPnyJnhoONHBNYcOHTLTh1944QU5ffq0GcTap08fE0BcMTExsnjxYhk8eLBpTSldurQZwxJ83hQAAICIAsqsWbPOu04DiQ6WvRid5bNkyRKOPAAAOC9+iwcAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAeDugzJgxQ5o2bSrlypUzS5s2beTjjz8OrD9z5owMGTJE4uPjpUyZMtKnTx85evRoyH0cPHhQunfvLqVKlZLKlSvLyJEj5dy5c/lXIgAAcGkFlOrVq8uUKVNk69atsmXLFmnfvr307NlTdu3aZdYPHz5cFi1aJPPnz5e1a9fKDz/8IL179w78fWZmpgknZ8+elQ0bNsjcuXNlzpw5Mn78+PwvGQAA8KxikWzco0ePkOuTJk0yrSobN2404WXWrFkyb948E1zU7NmzpUGDBmb9DTfcIMuXL5fdu3fLypUrpUqVKtK8eXOZOHGijBo1ShITE6V48eL5WzoAAOD/gBJMW0O0peT06dOmq0dbVTIyMqRjx46BberXry81a9aU5ORkE1D0skmTJiacuLp06SKDBw82rTAtWrTI8bHS09PN4kpNTTWX+ni65Cf3/uKiHfGS3BwHd5v8Pma2oHzeRd15m5/rz89lK4ryRfI4EQeUHTt2mECi4010nMmCBQukYcOGsn37dtMCUqFChZDtNYwcOXLE/F8vg8OJu95ddz6TJ0+WpKSkbLdri4yOZSkIE1tliZcsWbIk19uuWLFC/IzyeRd1521+rj8/l60wy5eWllZwAeWaa64xYeTEiRPy3nvvSf/+/c14k4I0evRoGTFiREgLSo0aNaRz585msG5+pzutqHFboiU9K0q8Ymdil1yXrVOnThIbGyt+Q/m8i7rzNj/Xn5/LVhTlc3tACiSgaCtJvXr1zP9btmwpmzdvlmnTpsldd91lBr8eP348pBVFZ/EkJCSY/+vlpk2bQu7PneXjbpOTuLg4s4TTg1lQB1TDSXqmdwJKJMehII+bDSifd1F33ubn+vNz2QqzfJE8xq8+D0pWVpYZH6JhRR941apVgXV79uwx04q1S0jppXYRpaSkBLbR5KatINpNBAAAEHELina1dO3a1Qx8PXnypJmxs2bNGlm2bJmUL19eBgwYYLpiKlasaELHo48+akKJDpBV2iWjQaRfv34ydepUM+5k7Nix5twpObWQAACAS1NEAUVbPu6//345fPiwCSR60jYNJ9p3pZ5//nmJjo42J2jTVhWdofPKK68E/j4mJkYWL15sZu1ocCldurQZwzJhwoT8LxkAALg0Aoqe5+RCSpQoIdOnTzfL+dSqVSuiGScAAODSw2/xAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIC3A8rkyZPluuuuk7Jly0rlypWlV69esmfPnpBt2rVrJ1FRUSHLww8/HLLNwYMHpXv37lKqVClzPyNHjpRz587lT4kAAIDnFYtk47Vr18qQIUNMSNFAMWbMGOncubPs3r1bSpcuHdhu4MCBMmHChMB1DSKuzMxME04SEhJkw4YNcvjwYbn//vslNjZWnnnmmfwqFwAAuFQCytKlS0Ouz5kzx7SAbN26VW655ZaQQKIBJCfLly83gWblypVSpUoVad68uUycOFFGjRoliYmJUrx48Wx/k56ebhZXamqquczIyDBLfnLvLy7aES/JzXFwt8nvY2YLyudd1J23+bn+/Fy2oihfJI8T5ThOnj+J9+3bJ1dddZXs2LFDGjduHOji2bVrl+jdakjp0aOHjBs3LtCKMn78ePnwww9l+/btgfs5cOCA1KlTR7Zt2yYtWrTI9jgaXJKSkrLdPm/evJDWGQAAYK+0tDS599575cSJE1KuXLn8a0EJlpWVJcOGDZObbropEE6UPnCtWrWkWrVq8sUXX5iWER2n8v7775v1R44cMS0nwdzrui4no0ePlhEjRoS0oNSoUcN0L12sgHlJdytWrJBxW6IlPStKvGJnYpdcl61Tp06mS81vKJ93UXfe5uf683PZiqJ8bg9IbuQ5oOhYlJ07d8r69etDbh80aFDg/02aNJGqVatKhw4dZP/+/VK3bt08PVZcXJxZwunBLKgDquEkPdM7ASWS41CQx80GlM+7qDtv83P9+blshVm+SB4jT9OMhw4dKosXL5ZPPvlEqlevfsFtW7duHegOUtrtc/To0ZBt3OvnG7cCAAAuLREFFB1XouFkwYIFsnr1aqldu/ZF/8Yda6ItKapNmzZmzEpKSkpgG21e0q6ahg0bRl4CAADgO8Ui7dbRgakffPCBOReKO2akfPnyUrJkSdONo+u7desm8fHxZgzK8OHDzQyfpk2bmm113IgGkX79+snUqVPNfYwdO9bcd07dOAAA4NITUQvKjBkzzMhbnamjLSLu8s4775j1OkVYpw9rCKlfv748/vjj0qdPH1m0aFHgPmJiYkz3kF5qa8p9991nzoMSfN4UAABwaYuoBeViM5J1Zo2ezO1idJbPkiVLInloAABwCeG3eAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAtwPK5MmT5brrrpOyZctK5cqVpVevXrJnz56Qbc6cOSNDhgyR+Ph4KVOmjPTp00eOHj0ass3Bgwele/fuUqpUKXM/I0eOlHPnzuVPiQAAwKUVUNauXWvCx8aNG2XFihWSkZEhnTt3ltOnTwe2GT58uCxatEjmz59vtv/hhx+kd+/egfWZmZkmnJw9e1Y2bNggc+fOlTlz5sj48ePzt2QAAMCzikWy8dKlS0Oua7DQFpCtW7fKLbfcIidOnJBZs2bJvHnzpH379mab2bNnS4MGDUyoueGGG2T58uWye/duWblypVSpUkWaN28uEydOlFGjRkliYqIUL148f0sIAAD8HVDCaSBRFStWNJcaVLRVpWPHjoFt6tevLzVr1pTk5GQTUPSySZMmJpy4unTpIoMHD5Zdu3ZJixYtsj1Oenq6WVypqanmUh9Ll/zk3l9ctCNekpvj4G6T38fMFpTPu6g7b/Nz/fm5bEVRvkgeJ88BJSsrS4YNGyY33XSTNG7c2Nx25MgR0wJSoUKFkG01jOg6d5vgcOKud9edb+xLUlJSttu1NUbHsRSEia2yxEuWLFmS6221e87PKJ93UXfe5uf683PZCrN8aWlpBR9QdCzKzp07Zf369VLQRo8eLSNGjAhpQalRo4YZ/1KuXLl8T3daUeO2REt6VpR4xc7ELrkuW6dOnSQ2Nlb8hvJ5F3XnbX6uPz+XrSjK5/aAFFhAGTp0qCxevFjWrVsn1atXD9yekJBgBr8eP348pBVFZ/HoOnebTZs2hdyfO8vH3SZcXFycWcLpwSyoA6rhJD3TOwElkuNQkMfNBpTPu6g7b/Nz/fm5bIVZvkgeI6JZPI7jmHCyYMECWb16tdSuXTtkfcuWLc2Dr1q1KnCbTkPWacVt2rQx1/Vyx44dkpKSEthG05u2hDRs2DCS3QEAAD5VLNJuHZ2h88EHH5hzobhjRsqXLy8lS5Y0lwMGDDDdMTpwVkPHo48+akKJDpBV2i2jQaRfv34ydepUcx9jx441951TKwkAALj0RBRQZsyYYS7btWsXcrtOJX7ggQfM/59//nmJjo42J2jTmTc6Q+eVV14JbBsTE2O6h3TWjgaX0qVLS//+/WXChAn5UyIAAHBpBRTt4rmYEiVKyPTp081yPrVq1Ypo1gkAALi08Fs8AADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAOD9gLJu3Trp0aOHVKtWTaKiomThwoUh6x944AFze/By++23h2xz7Ngx6du3r5QrV04qVKggAwYMkFOnTv360gAAgEszoJw+fVqaNWsm06dPP+82GkgOHz4cWN56662Q9RpOdu3aJStWrJDFixeb0DNo0KC8lQAAAPhOsUj/oGvXrma5kLi4OElISMhx3ZdffilLly6VzZs3S6tWrcxtL730knTr1k2effZZ0zIDAAAubREHlNxYs2aNVK5cWS677DJp3769PP300xIfH2/WJScnm24dN5yojh07SnR0tHz66ady5513Zru/9PR0s7hSU1PNZUZGhlnyk3t/cdGOeElujoO7TX4fM1tQPu+i7rzNz/Xn57IVRfkieZwox3Hy/Ems40sWLFggvXr1Ctz29ttvS6lSpaR27dqyf/9+GTNmjJQpU8YEk5iYGHnmmWdk7ty5smfPnpD70kCTlJQkgwcPzvY4iYmJZl24efPmmccCAAD2S0tLk3vvvVdOnDhhxqEWagvK3XffHfh/kyZNpGnTplK3bl3TqtKhQ4c83efo0aNlxIgRIS0oNWrUkM6dO1+0gHlJdzo2ZtyWaEnPihKv2JnYJddl69Spk8TGxorfUD7vou68zc/15+eyFUX53B6QIuviCVanTh2pVKmS7Nu3zwQUHZuSkpISss25c+fMzJ7zjVvRMS26hNODWVAHVMNJeqZ3Akokx6Egj5sNKJ93UXfe5uf683PZCrN8kTxGgZ8H5bvvvpOff/5Zqlataq63adNGjh8/Llu3bg1ss3r1asnKypLWrVsX9O4AAAAPiLgFRc9Xoq0hrgMHDsj27dulYsWKZtGxIn369DGtIToG5YknnpB69epJly7/2wXRoEEDMw154MCBMnPmTNO8NHToUNM1xAweAACQpxaULVu2SIsWLcyidGyI/n/8+PFmEOwXX3whd9xxh1x99dXmBGwtW7aU//mf/wnponnzzTelfv36pstHpxe3bdtWXn31VWoEAADkrQWlXbt2cqGJP8uWLbvofWhLi87AAQAAyAm/xQMAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAAvB9Q1q1bJz169JBq1apJVFSULFy4MGS94zgyfvx4qVq1qpQsWVI6duwoe/fuDdnm2LFj0rdvXylXrpxUqFBBBgwYIKdOnfr1pQEAAJdmQDl9+rQ0a9ZMpk+fnuP6qVOnyosvvigzZ86UTz/9VEqXLi1dunSRM2fOBLbRcLJr1y5ZsWKFLF682ISeQYMG/bqSAAAA3ygW6R907drVLDnR1pMXXnhBxo4dKz179jS3/f3vf5cqVaqYlpa7775bvvzyS1m6dKls3rxZWrVqZbZ56aWXpFu3bvLss8+alhkAAHBpizigXMiBAwfkyJEjplvHVb58eWndurUkJyebgKKX2q3jhhOl20dHR5sWlzvvvDPb/aanp5vFlZqaai4zMjLMkp/c+4uLdsRLcnMc3G3y+5jZgvJ5F3XnbX6uPz+XrSjKF8nj5GtA0XCitMUkmF531+ll5cqVQ3eiWDGpWLFiYJtwkydPlqSkpGy3L1++XEqVKiUFYWKrLPGSJUuW5Hpb7VrzM8rnXdSdt/m5/vxctsIsX1paWtEElIIyevRoGTFiREgLSo0aNaRz585moG1+pzutqHFboiU9K0q8Ymdil1yXrVOnThIbGyt+Q/m8i7rzNj/Xn5/LVhTlc3tACj2gJCQkmMujR4+aWTwuvd68efPANikpKSF/d+7cOTOzx/37cHFxcWYJpwezoA6ohpP0TO8ElEiOQ0EeNxtQPu+i7rzNz/Xn57IVZvkieYx8PQ9K7dq1TchYtWpVSFrSsSVt2rQx1/Xy+PHjsnXr1sA2q1evlqysLDNWBQAAIOIWFD1fyb59+0IGxm7fvt2MIalZs6YMGzZMnn76abnqqqtMYBk3bpyZmdOrVy+zfYMGDeT222+XgQMHmqnI2rw0dOhQM4CWGTwAACBPAWXLli1y2223Ba67Y0P69+8vc+bMkSeeeMKcK0XPa6ItJW3btjXTikuUKBH4mzfffNOEkg4dOpjZO3369DHnTgEAAMhTQGnXrp0538n56NllJ0yYYJbz0daWefPmUQMAACBH/BYPAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAPg/oCQmJkpUVFTIUr9+/cD6M2fOyJAhQyQ+Pl7KlCkjffr0kaNHj+b3bgAAAA8rkBaURo0ayeHDhwPL+vXrA+uGDx8uixYtkvnz58vatWvlhx9+kN69exfEbgAAAI8qViB3WqyYJCQkZLv9xIkTMmvWLJk3b560b9/e3DZ79mxp0KCBbNy4UW644YaC2B0AAOAxBRJQ9u7dK9WqVZMSJUpImzZtZPLkyVKzZk3ZunWrZGRkSMeOHQPbavePrktOTj5vQElPTzeLKzU11VzqfemSn9z7i4t2xEtycxzcbfL7mNmC8nkXdedtfq4/P5etKMoXyeNEOY6Tr5/EH3/8sZw6dUquueYa072TlJQk33//vezcudN07Tz44IMhYUNdf/31ctttt8mf//zn845r0fsJpy0xpUqVys/dBwAABSQtLU3uvfde06NSrly5wg0o4Y4fPy61atWS5557TkqWLJmngJJTC0qNGjXkp59+umgB85LuVqxYIeO2REt6VpR4xc7ELrkuW6dOnSQ2Nlb8hvJ5F3XnbX6uPz+XrSjKp5/flSpVylVAKZAunmAVKlSQq6++Wvbt22cOwNmzZ01o0dtdOosnpzErrri4OLOE04NZUAdUw0l6pncCSiTHoSCPmw0on3dRd97m5/rzc9kKs3yRPEaBnwdFu3v2798vVatWlZYtW5qdW7VqVWD9nj175ODBg2asCgAAQIG0oPzxj3+UHj16mG4dnUL81FNPSUxMjNxzzz1Svnx5GTBggIwYMUIqVqxomnceffRRE06YwQMAAAosoHz33XcmjPz8889y+eWXS9u2bc0UYv2/ev755yU6OtqcoE3HlXTp0kVeeeWV/N4NAADgYfkeUN5+++0Lrtepx9OnTzcLAABATvgtHgAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAAGAdAgoAALAOAQUAAFiHgAIAAKxDQAEAANYhoAAAAOsQUAAAgHUIKAAAwDoEFAAAYB0CCgAAsA4BBQAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoAADAOgQUAABgnSINKNOnT5crr7xSSpQoIa1bt5ZNmzYV5e4AAIBLPaC88847MmLECHnqqadk27Zt0qxZM+nSpYukpKQU1S4BAABLFCuqB37uuedk4MCB8uCDD5rrM2fOlI8++khef/11efLJJ4tqt1CIrnzyo3y9v7gYR6ZeL9I4cZmkZ0ZJQfhmSvcCuV8AgAUB5ezZs7J161YZPXp04Lbo6Gjp2LGjJCcnZ9s+PT3dLK4TJ06Yy2PHjklGRka+7pveX1pamhTLiJbMrIL5kCsI9f747kW3iYt2ZGyLLGn+p/cl3YKy5feTr1iWI2lpWQVadz///HOB3G8kz03dh9jYWPETP5St9eRVnnntuT4d3SFf7scP9VeQZbvQc6OoxV3guZlfz49gJ0+eNJeO41x8Y6cIfP/997pnzoYNG0JuHzlypHP99ddn2/6pp54y27NwDHgO8BzgOcBzgOeAeP4YHDp06KJZoci6eCKhLS06XsWVlZVlWk/i4+MlKip/v42kpqZKjRo15NChQ1KuXDnxEz+XTVE+76LuvM3P9efnshVF+bTlRFtRqlWrdtFtiySgVKpUSWJiYuTo0aMht+v1hISEbNvHxcWZJViFChUKdB+1ovz4ZPR72RTl8y7qztv8XH9+Llthl698+fL2zuIpXry4tGzZUlatWhXSKqLX27RpUxS7BAAALFJkXTzaZdO/f39p1aqVXH/99fLCCy/I6dOnA7N6AADApavIAspdd90lP/74o4wfP16OHDkizZs3l6VLl0qVKlWkKGlXkp6bJbxLyQ/8XDZF+byLuvM2P9efn8tme/midKRsUe8EAABAMH6LBwAAWIeAAgAArENAAQAA1iGgAAAA6xBQAACAdQgoQaZPny5XXnmllChRQlq3bi2bNm0SL1q3bp306NHDnEpYfwpg4cKFIet14pZO765ataqULFnS/Ejj3r17xQsmT54s1113nZQtW1YqV64svXr1kj179oRsc+bMGRkyZIj5KYQyZcpInz59sp212FYzZsyQpk2bBs7qqCcu/Pjjj31RtnBTpkwxz89hw4b5onyJiYmmPMFL/fr1fVE21/fffy/33XefKYO+dzRp0kS2bNnii/cWfe8Prz9dtM68Xn+ZmZkybtw4qV27tqmXunXrysSJE0N+sM/KusvPHwH0srffftspXry48/rrrzu7du1yBg4c6FSoUME5evSo4zVLlixx/vSnPznvv/+++VGmBQsWhKyfMmWKU758eWfhwoXO559/7txxxx1O7dq1nV9++cWxXZcuXZzZs2c7O3fudLZv3+5069bNqVmzpnPq1KnANg8//LBTo0YNZ9WqVc6WLVucG264wbnxxhsdL/jwww+djz76yPnqq6+cPXv2OGPGjHFiY2NNeb1etmCbNm1yrrzySqdp06bOY489Frjdy+XTHzVt1KiRc/jw4cDy448/+qJs6tixY06tWrWcBx54wPn000+dr7/+2lm2bJmzb98+X7y3pKSkhNTdihUrzPvnJ5984vn6mzRpkhMfH+8sXrzYOXDggDN//nynTJkyzrRp06yuOwLK/9FfUR4yZEjgwGRmZjrVqlVzJk+e7HhZeEDJyspyEhISnL/85S+B244fP+7ExcU5b731luM1+qaiZVy7dm2gLPqBri9A15dffmm2SU5Odrzosssuc/72t7/5pmwnT550rrrqKvMBcOuttwYCitfLpwGlWbNmOa7zetnUqFGjnLZt2553vd/eW/R5WbduXVMur9df9+7dnYceeijktt69ezt9+/a1uu7o4hGRs2fPytatW02Tlis6OtpcT05OFj85cOCAOXNvcFn1h5u0S8uLZT1x4oS5rFixornUeszIyAgpnzaz16xZ03Pl02bZt99+2/wEhHb1+KVs2kzevXv3kHIoP5RPm8S1a7VOnTrSt29fOXjwoG/K9uGHH5qfJvntb39ruldbtGghr732mi/fW/Qz4Y033pCHHnrIdPN4vf5uvPFG81t3X331lbn++eefy/r166Vr165W112RnereJj/99JP5MAg/zb5e/9e//iV+ok9ClVNZ3XVeoT8wqeMXbrrpJmncuLG5TcugP0YZ/mvXXirfjh07TCDRPm/t616wYIE0bNhQtm/f7vmyaeDatm2bbN68Ods6r9edvpnPmTNHrrnmGjl8+LAkJSXJzTffLDt37vR82dTXX39txkjp76iNGTPG1OEf/vAHUy79XTU/vbfouL3jx4/LAw88YK57vf6efPJJSU1NNaEqJibGfN5NmjTJhGhla90RUOBZ+k1c3/z1m4Cf6AechhFtHXrvvffMm//atWvF6w4dOiSPPfaYrFixwgxE9xv326jSgc4aWGrVqiXvvvuuGXTodfqFQFtQnnnmGXNdW1D09Tdz5kzzHPWTWbNmmfrU1jA/ePfdd+XNN9+UefPmSaNGjcz7i3650/LZXHd08YhIpUqVTKoMH5Gt1xMSEsRP3PJ4vaxDhw6VxYsXyyeffCLVq1cP3K5l0OZZ/fbj1fLpN7V69epJy5YtzaylZs2aybRp0zxfNm0mT0lJkWuvvVaKFStmFg1eL774ovm/flvzcvnC6bftq6++Wvbt2+f5ulM6u0Nb8oI1aNAg0I3ll/eWb7/9VlauXCm/+93vArd5vf5GjhxpWlHuvvtuM/OqX79+Mnz4cPP+YnPdEVD+7wNBPwy0jy7424Je16Z2P9FpZvqECy6rNv19+umnniirjvvVcKLdHqtXrzblCab1GBsbG1I+nYasb6JeKF9O9LmYnp7u+bJ16NDBdF/ptzd30W/k2szs/t/L5Qt36tQp2b9/v/lg93rdKe1KDZ/Sr2MatJXID+8trtmzZ5sxNjpOyuX1+ktLSzPjKoPpl3J9b7G67opseK6F04x1xPKcOXOc3bt3O4MGDTLTjI8cOeJ4jc6S+Oyzz8yiVfzcc8+Z/3/77beB6WRatg8++MD54osvnJ49exb5dLLcGjx4sJkKt2bNmpApgWlpaYFtdDqgTj1evXq1mQ7Ypk0bs3jBk08+aWYk6VRArRu9HhUV5SxfvtzzZctJ8Cwer5fv8ccfN89Lrbt//vOfTseOHZ1KlSqZmWZeL5s7NbxYsWJmyurevXudN9980ylVqpTzxhtvBLbx8nuLO3tT60hnLIXzcv3179/fueKKKwLTjPUUFPrcfOKJJ6yuOwJKkJdeesk8AfV8KDrteOPGjY4X6bx9DSbhiz5J3Sll48aNc6pUqWJCWYcOHcw5N7wgp3LpoudGcekL6pFHHjHTc/UN9M477zQhxgt0KqCea0Kfg5dffrmpGzeceL1suQkoXi7fXXfd5VStWtXUnX4Y6PXgc4R4uWyuRYsWOY0bNzbvG/Xr13deffXVkPVefm9Rel4XfT/JaZ+9XH+pqanmdaafbyVKlHDq1KljzpWVnp5udd1F6T9F134DAACQHWNQAACAdQgoAADAOgQUAABgHQIKAACwDgEFAABYh4ACAACsQ0ABAADWIaAAAADrEFAAAIB1CCgAAMA6BBQAACC2+X/pCCt4OK3PUwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Quickly check the distribution of the platform_divided_by_dr_line_count column\n",
+    "merged_df.replace(np.inf, np.nan).hist(column='platform_divided_by_dr_line_count', bins=10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.10.6)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/analysis/2026-03_entity_counts_check/README.md
+++ b/analysis/2026-03_entity_counts_check/README.md
@@ -11,6 +11,7 @@ This analysis investigates whether entity counts are consistent across the data 
 
 - **[1_initial_check_with_all_data.ipynb](1_initial_check_with_all_data.ipynb)** — initial (incorrect) approach; do not use for conclusions
 - **[2_comparing_reporting_historic_endpoints_with_dataset_resource.ipynb](2_comparing_reporting_historic_endpoints_with_dataset_resource.ipynb)** — corrected analysis with valid findings
+- **[3_final_report_csv.ipynb](3_final_report_csv.ipynb)** — final analysis comparing platform entity counts with dataset_resource counts; precursor to the daily report in `reporting-task`
 
 ---
 
@@ -19,6 +20,7 @@ This analysis investigates whether entity counts are consistent across the data 
 This notebook compared entity counts across three sources: the Planning platform (published data), `reporting_historic_endpoints`, and transformed resources. The approach was flawed because the platform data has been pruned and filtered before publication, so comparing it against backend pipeline data will naturally produce mismatches that are not indicative of a real problem.
 
 **Results (not meaningful):**
+
 - Platform vs `dataset_resource`: 230 mismatches, 53 matches
 - Platform vs transformed resources: 104 mismatches, 180 matches
 
@@ -31,10 +33,12 @@ These figures should be ignored — they reflect the expected difference between
 This notebook corrects the approach by comparing only within the backend pipeline: `reporting_historic_endpoints` entity counts against counts derived directly from transformed resource CSV files. This is a like-for-like comparison at the same stage of the pipeline.
 
 Additional fixes over Notebook 1:
+
 - Deduplicated resources in `reporting_historic_endpoints` before merging (Notebook 1 was inflating counts by keeping duplicates)
 - Used `_stream=on` when fetching `dataset_resource` CSVs rather than `_size=max`
 
 **Data sources:**
+
 - `reporting_historic_endpoints` — fetched from Datasette with pagination (`rowid__gt` loop)
 - `dataset_resource` — CSV exports from Datasette per dataset
 - Transformed resources — individual CSV files from `files.planning.data.gov.uk/[collection]-collection/transformed/[dataset]/[resource_hash].csv`
@@ -52,3 +56,30 @@ When aggregated to LPA level, there are no mismatches at all.
 ### Conclusion
 
 Entity counts between `reporting_historic_endpoints` and transformed resources are fully consistent at the LPA level. The backend pipeline data is internally coherent for the four datasets tested.
+
+---
+
+## Notebook 3 — Final report (for conversion to daily reporting task)
+
+This notebook compares platform entity counts with the `dataset_resource` / `reporting_historic_endpoints` entity, entry, and line counts. It is the final piece of analysis before being converted into a daily report run within the `reporting-task` repository. It focuses on all five ODP datasets.
+
+**Data sources:**
+
+- Platform entity data — CSV exports from `files.planning.data.gov.uk/dataset/[dataset].csv`
+- `reporting_historic_endpoints` — fetched from Datasette (`performance` database) with pagination
+- `dataset_resource` — CSV exports from Datasette per dataset database
+
+**Datasets in scope:** `article-4-direction-area`, `conservation-area`, `listed-building-outline`, `tree`, `tree-preservation-zone`
+
+### Outputs
+
+Two reports are produced:
+
+1. **Summary table** (`dataset_resource_vs_platform_odp_summary.csv`) — compares platform entity counts and dataset_resource line counts for each LPA across the ODP datasets. Line counts are used rather than entity counts to account for potential erroneous 0/NaN values appearing in the `entity_count` column of some dataset-level databases.
+
+2. **Detailed table** (`dataset_resource_odp_detailed_counts.csv`) — shows the counts per resource for each LPA across the ODP datasets, with the full merge of `reporting_historic_endpoints` and `dataset_resource`.
+
+### Notes
+
+- The `entity_count` column in dataset-level datasette databases (e.g. `article-4-direction-area/dataset_resource`) can contain NaN for resources where the collection-level database (e.g. `article-4-direction/dataset_resource`) has a valid count. Line counts are used as a more reliable proxy.
+- Resources are deduplicated in `reporting_historic_endpoints` before merging to avoid inflating counts.


### PR DESCRIPTION
This PR builds upon previous work in #100. This notebook was the preliminary and final code that was then fed into a new reporting task, created in this reporting-task PR: https://github.com/digital-land/reporting-task/pull/19

Related ticket: https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=190097349&issue=digital-land%7Cconfig%7C2619

## Summary

- Adds notebook comparing platform entity counts against `dataset_resource` line counts from `reporting_historic_endpoints` for the five ODP datasets (`article-4-direction-area`, `conservation-area`, `listed-building-outline`, `tree`, `tree-preservation-zone`)
- Produces two output CSVs: a summary table per LPA and a detailed table per resource
- Uses line counts instead of entity counts as the comparison metric, due to NaN/0 values in the `entity_count` column of dataset-level datasette databases
- This is the final exploratory analysis before converting the logic into a daily report in `reporting-task`
